### PR TITLE
Update sed usage for compatibility with both bsd and gnu sed

### DIFF
--- a/scripts/helmify-yaml
+++ b/scripts/helmify-yaml
@@ -2,15 +2,15 @@
 
 set -euo pipefail
 
-sed -i '.temp' \
+sed -i'.temp' \
     's/projects-manager-role/"{{ template "projects-operator.fullname" . }}-manager-role"/g' \
     helm/projects-operator/templates/manager-role.yaml
 
-sed -i '.temp' \
+sed -i'.temp' \
     's/projectaccesses-manager-role/"{{ template "projects-operator.fullname" . }}-projectaccess-cluster-role"/g' \
     helm/projects-operator/templates/projectaccess-role.yaml
 
-sed -i '.temp' \
+sed -i'.temp' \
     's/projects-leader-election-role/"{{ template "projects-operator.fullname" . }}-leader-election-role"/g' \
     helm/projects-operator/templates/leader-election-role.yaml
 


### PR DESCRIPTION
Fortunately `sed -i'.temp'` works for both gnu and bsd `sed`. The issue would have been less pleasant if we were trying to use `sed -i ''` (i.e. not making a backup). See https://unix.stackexchange.com/questions/92895/how-can-i-achieve-portability-with-sed-i-in-place-editing.

Fixes https://github.com/pivotal/projects-operator/issues/53