### PR TITLE
Add optional flag to optional fields in project api

### DIFF
--- a/api/v1alpha1/project_types.go
+++ b/api/v1alpha1/project_types.go
@@ -18,13 +18,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // ProjectSpec defines the desired state of Project
 type ProjectSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	// +optional
 	Access []SubjectRef `json:"access,omitempty"`
 }
 
@@ -32,15 +28,15 @@ type ProjectSpec struct {
 type KindEnum string
 
 type SubjectRef struct {
-	Kind      KindEnum `json:"kind"`
-	Name      string   `json:"name"`
-	Namespace string   `json:"namespace,omitempty"`
+	Kind KindEnum `json:"kind"`
+	Name string   `json:"name"`
+
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // ProjectStatus defines the observed state of Project
 type ProjectStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/projectaccess_types.go
+++ b/api/v1alpha1/projectaccess_types.go
@@ -24,6 +24,7 @@ type ProjectAccessSpec struct {
 
 // ProjectAccessStatus defines the observed state of ProjectAccess
 type ProjectAccessStatus struct {
+	// +optional
 	Projects []string `json:"projects,omitempty"`
 }
 

--- a/helm/projects-operator/crds/projects.pivotal.io_projects.yaml
+++ b/helm/projects-operator/crds/projects.pivotal.io_projects.yaml
@@ -35,8 +35,6 @@ spec:
           description: ProjectSpec defines the desired state of Project
           properties:
             access:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "make" to regenerate code after modifying this file'
               items:
                 properties:
                   kind:


### PR DESCRIPTION
Other than a couple of missing +optional comments everything was actually fairly reasonable.

Closes https://github.com/pivotal/projects-operator/issues/40

cc @gmrodgers 