### PR TITLE
Fixing apiVersion to correspond to allowable value

### DIFF
--- a/helm/projects-operator/Chart.yaml
+++ b/helm/projects-operator/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1alpha1
+apiVersion: v2
 name: projects-operator
 description: A Helm chart to install the Projects Operator
 


### PR DESCRIPTION
See https://helm.sh/docs/topics/charts/#the-apiversion-field for an explanation, this was mistakenly switched to `v1alpha1` when we updated the CRD versions.